### PR TITLE
Tripletloss, TripletCNN and further Tensorflow 2 support

### DIFF
--- a/config_test/test_train_nodaug.yml
+++ b/config_test/test_train_nodaug.yml
@@ -1,0 +1,12 @@
+test:
+    orig:
+      daug_params: nodaug.yml
+      metrics: 
+        - accuracy 
+        - top3
+train:
+    orig:
+      daug_params: nodaug.yml
+      metrics: 
+        - accuracy 
+        - top3

--- a/config_train/cifar/tripletcnn/noreg_bn.yml
+++ b/config_train/cifar/tripletcnn/noreg_bn.yml
@@ -1,0 +1,46 @@
+network: 
+  name: tripletcnn
+  reg:
+    dropout: 0.
+    weight_decay: !!null
+  batch_norm: True
+optimizer:
+  name: Adam
+  loss: categorical_crossentropy
+#   momentum: 0.9
+#   nesterov: True
+  daug_invariance_params_file: noinv.yml
+  class_invariance_params_file: noinv.yml
+train:
+  lr:
+    init_lr: 0.001 
+    decay_factor: 0.1
+    decay_epochs: [300]
+  batch_size:
+    tr: 128
+    val: 128
+  epochs: 40
+  simulate:
+    bs_lr: bs # bs or lr
+    rep_samples: !!null
+    norep_samples: False
+    true_epochs: False
+data:
+  data_file: ~/datasets/hdf5/cifar10.hdf5
+  group_tr: cifar10_train
+  group_val: cifar10_test
+  shuffle_train_val: False
+  chunk_size: !!null
+  queue_size: 50
+daug:
+  nodaug: nodaug.yml
+  daug_params_file: nodaug.yml
+  aug_per_img_tr: 1
+  aug_per_img_val: 1
+seeds:
+  tf: 33
+  np: 39
+  daug: 59
+  batch_shuffle: 47
+  train_val: 27
+metrics: [accuracy]

--- a/examples/score-invariance.sh
+++ b/examples/score-invariance.sh
@@ -1,0 +1,16 @@
+for MODEL in r26 r29
+do
+    echo -e "\nCOMPUTING INVARIANCE FOR MODEL $MODEL\n"
+    for EPOCH in 010 020 030 040
+    do
+        echo -e "\nMODEL $MODEL, EPOCH $EPOCH\n"
+        python invariance_numpy.py \
+        --data_file ~/Storage/Datasets/cifar10/hdf5/cifar10.hdf5 \
+        --group test \
+        --daug_params heavier.yml \
+        --model log/cifar10/tripletcnn/noreg/bn/inv/$MODEL/model_*_$EPOCH \
+        --output_mse_matrix_hdf5 mse_matrix_ep$EPOCH \
+        --output_pickle invscores_ep$EPOCH \
+        --layer_regex flatten
+    done
+done

--- a/examples/score-test-prediction.sh
+++ b/examples/score-test-prediction.sh
@@ -1,0 +1,15 @@
+for MODEL in r26 r29
+do
+    for EPOCH in 010 020 030 040
+    do
+        echo -e "\nMODEL $MODEL, EPOCH $EPOCH\n"
+        python test.py \
+        --data_file ~/Storage/Datasets/cifar10/hdf5/cifar10.hdf5 \
+        --group_tr train \
+        --group_tt test \
+        --test_config config_test/test_train_nodaug.yml \
+        --model log/cifar10/tripletcnn/noreg/bn/inv/$MODEL/model_*_$EPOCH \
+        --output_dir -1 \
+        --output_basename testscores/testscore_ep$EPOCH 
+    done
+done

--- a/examples/train-tripletcnn-cifar-cls.sh
+++ b/examples/train-tripletcnn-cifar-cls.sh
@@ -1,0 +1,21 @@
+# This script trains the KHONSU architecture on CIFAR-10 with data 
+# augmentation and class triplet loss
+#
+# It is meant to to be run from the root of the repository
+# Consider changing the paths to files and directories
+#
+# CIFAR-10
+#
+# All-CNN
+#
+# no-reg bn heavier inv
+python train.py \
+--data_file ~/Storage/Datasets/cifar10/hdf5/cifar10.hdf5 \
+--group_tr train \
+--group_val test \
+--train_dir ./log/cifar10/tripletcnn/noreg/bn/inv/r24/ \
+--daug_params heavier.yml \
+--train_config_file config_train/cifar/tripletcnn/noreg_bn.yml \
+--resume_training log/cifar10/tripletcnn/noreg/bn/inv/r17/model_Mon_20_Jul_2020_160756_120 \
+--save_model_every 10 \
+--no_fit_generator

--- a/examples/train-tripletcnn-cifar-daug.sh
+++ b/examples/train-tripletcnn-cifar-daug.sh
@@ -13,8 +13,13 @@ python train.py \
 --data_file ~/Storage/Datasets/cifar10/hdf5/cifar10.hdf5 \
 --group_tr train \
 --group_val test \
---train_dir ./log/cifar10/tripletcnn/noreg/bn/inv/r24/ \
+--train_dir ./log/cifar10/tripletcnn/noreg/bn/inv/r31/ \
 --daug_params heavier.yml \
 --train_config_file config_train/cifar/tripletcnn/noreg_bn.yml \
+--aug_per_img_tr 16 \
+--daug_invariance_params loss1_exp.yml \
+--class_invariance_params noinv.yml \
 --save_model_every 10 \
---no_fit_generator
+--no_fit_generator \
+--resume_training ./log/cifar10/tripletcnn/noreg/bn/inv/r31/model_*_030 \
+--triplet_loss 

--- a/examples/train-tripletcnn-cifar-daug.sh
+++ b/examples/train-tripletcnn-cifar-daug.sh
@@ -10,7 +10,7 @@
 #
 # no-reg bn heavier inv
 python train.py \
---data_file ~/Storage/Datasets/cifar10/hdf5/cifar10.hdf5 \
+--data_file /datasets/hdf5/cifar10.hdf5 \
 --group_tr train \
 --group_val test \
 --train_dir ./log/cifar10/tripletcnn/noreg/bn/inv/r31/ \
@@ -21,5 +21,4 @@ python train.py \
 --class_invariance_params noinv.yml \
 --save_model_every 10 \
 --no_fit_generator \
---resume_training ./log/cifar10/tripletcnn/noreg/bn/inv/r31/model_*_030 \
 --triplet_loss 

--- a/invariance.py
+++ b/invariance.py
@@ -26,7 +26,7 @@ from dask.diagnostics import ProgressBar
 
 from data_input import hdf52dask, get_generator, batch_generator
 from utils import get_daug_scheme_path
-from utils import pairwise_loss, mean_loss, invariance_loss
+from utils import pairwise_loss, mean_loss, invariance_loss, triplet_loss
 from activations import get_activations
 
 import keras.backend as K

--- a/invariance.py
+++ b/invariance.py
@@ -29,12 +29,9 @@ from utils import get_daug_scheme_path
 from utils import pairwise_loss, mean_loss, invariance_loss, triplet_loss
 from activations import get_activations
 
-import keras.backend as K
-from keras.models import load_model
-import keras.losses
-keras.losses.pairwise_loss = pairwise_loss
-keras.losses.invariance_loss = invariance_loss
-keras.losses.mean_loss = mean_loss
+import tensorflow.compat.v1.keras.backend as K
+from tensorflow.compat.v1.keras.models import load_model
+import tensorflow.compat.v1.keras.losses
 
 import os
 import argparse

--- a/invariance_numpy.py
+++ b/invariance_numpy.py
@@ -1,0 +1,341 @@
+"""
+Routine for computing the layer-wise data augmentation invariance of a model's
+activations.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from scipy.io import savemat
+
+import h5py
+import pickle
+import dask.array as da
+import dask
+from dask.diagnostics import ProgressBar
+# See: https://docs.dask.org/en/latest/diagnostics-local.html
+
+# Dask distributed
+# See: https://docs.dask.org/en/latest/scheduling.html
+# See: https://docs.dask.org/en/latest/setup/single-distributed.html
+# from dask.distributed import Client, LocalCluster
+
+from data_input import hdf52dask, get_generator, batch_generator
+from utils import get_daug_scheme_path
+from utils import pairwise_loss, mean_loss, invariance_loss, triplet_loss
+from activations import get_activations
+
+import tensorflow.compat.v1 as tf
+from tensorflow.compat.v1 import keras
+import tensorflow.compat.v1.keras.backend as K
+from tensorflow.compat.v1.keras.models import load_model
+import tensorflow.compat.v1.keras.losses
+
+# Disable eager execution, otherwise K.function will not work when passing
+# K.learning_phase() as input (see issue
+# https://github.com/tensorflow/tensorflow/issues/34201)
+#tf.disable_eager_execution()
+
+import os
+import argparse
+import shutil
+from tqdm import tqdm, trange
+from time import time
+
+import re
+
+# Initialize the Flags container
+FLAGS = None
+
+#def get_activations(model, batch_gen):
+
+
+def main(argv=None):
+
+    config = tf.ConfigProto()
+    config.gpu_options.allow_growth = True
+    #config.gpu_options.per_process_gpu_memory_fraction = 0.6
+    K.set_session(tf.Session(config=config))
+
+#     cluster = LocalCluster(dashboard_address=None)
+#     client = Client(cluster, memory_limit='{}GB'.format(FLAGS.memory_limit),
+#                     processes=False)
+
+    K.set_floatx('float32')
+
+    chunk_size = FLAGS.chunk_size
+
+    # Read data set
+    hdf5_file = h5py.File(FLAGS.data_file, 'r')
+    images, labels, _ = hdf52dask(hdf5_file, FLAGS.group, chunk_size,
+                                  shuffle=FLAGS.shuffle, seed=FLAGS.seed, 
+                                  pct=FLAGS.pct)
+    n_images = images.shape[0]
+    n_batches = int(np.ceil(n_images / float(FLAGS.batch_size)))
+
+    # Data augmentation parameters
+    daug_params_file = get_daug_scheme_path(FLAGS.daug_params, FLAGS.data_file)
+    daug_params = yaml.load(open(daug_params_file, 'r'),
+                            Loader=yaml.FullLoader)
+    nodaug_params_file = get_daug_scheme_path('nodaug.yml', FLAGS.data_file)
+    nodaug_params = yaml.load(open(nodaug_params_file, 'r'),
+                              Loader=yaml.FullLoader)
+
+    # Initialize the network model
+    model_filename = FLAGS.model
+    model = load_model(
+        model_filename, 
+        custom_objects = {
+            'invariance_loss': invariance_loss,
+            'triplet_loss': triplet_loss,
+            'pairwise_loss': pairwise_loss,
+            'mean_loss': mean_loss
+            })
+
+    # Print the model summary
+    model.summary()
+
+    # Get relevant layers
+    if FLAGS.store_input:
+        layer_regex = '({}|.*input.*)'.format(FLAGS.layer_regex)
+    else:
+        layer_regex = FLAGS.layer_regex
+
+    layers = [layer.name for layer in model.layers 
+              if re.compile(layer_regex).match(layer.name)]
+
+    # Create batch generators
+    n_daug_rep = FLAGS.n_daug_rep
+    n_diff_per_batch = int(FLAGS.batch_size / n_daug_rep)
+    image_gen_daug = get_generator(images, **daug_params)
+    batch_gen_daug = batch_generator(image_gen_daug, images, labels, 
+                                     batch_size=n_diff_per_batch, 
+                                     aug_per_im=n_daug_rep, 
+                                     shuffle=False)
+    image_gen_nodaug = get_generator(images, **nodaug_params)
+    batch_gen_nodaug = batch_generator(image_gen_nodaug, images, labels, 
+                                        FLAGS.batch_size, aug_per_im=1, 
+                                        shuffle=False)
+
+    # Outputs
+    if FLAGS.output_dir == '-1':
+        FLAGS.output_dir = os.path.dirname(FLAGS.model)
+
+    output_hdf5 = h5py.File(os.path.join(
+        FLAGS.output_dir, FLAGS.output_mse_matrix_hdf5), 'w')
+    output_pickle = os.path.join(FLAGS.output_dir, FLAGS.output_pickle)
+    df_init_idx = 0
+    df = pd.DataFrame()
+
+    # Iterate over the layers
+    for layer_idx, layer_name in enumerate(layers):
+
+        # Reload the model
+        if layer_idx > 0:
+            K.clear_session()
+            model = load_model(
+                model_filename, 
+                custom_objects = {
+                    'invariance_loss': invariance_loss,
+                    'triplet_loss': triplet_loss,
+                    'pairwise_loss': pairwise_loss,
+                    'mean_loss': mean_loss
+                    })
+
+        layer = model.get_layer(layer_name)
+
+        # Rename input layer
+        if re.compile('.*input.*').match(layer_name):
+            layer_name = 'input'
+
+        hdf5_layer = output_hdf5.create_group(layer_name)
+
+        activation_function = K.function([model.input], 
+                                          #K.learning_phase()], 
+                                         [layer.output])
+        #activation_function = keras.models.Model([model.input], [layer.output])
+        print('\nComputing pairwise similarity at layer {}'.format(layer_name))
+
+        # Compute activations of original data (without augmentation)
+        a_nodaug_da = get_activations(activation_function, batch_gen_nodaug).compute()
+        a_nodaug_da = np.squeeze(a_nodaug_da)
+        dim_activations = a_nodaug_da.shape[1]
+
+        # Comute matrix of similarities
+        r = np.reshape(np.sum(np.square(a_nodaug_da), axis=1), (-1, 1))
+        mse_matrix = (r - 2 * np.dot(a_nodaug_da,
+                                     np.transpose(a_nodaug_da)) \
+                     + np.transpose(r)) / dim_activations
+
+        # Compute activations with augmentation
+        a_daug_da = get_activations(activation_function, batch_gen_daug).compute()
+
+        # Compute similarity of augmentations with respect to the
+        # activations of the original data
+        a_nodaug_da = np.repeat(np.reshape(a_nodaug_da, 
+                                        a_nodaug_da.shape + (1, )), 
+                             repeats=n_daug_rep, axis=2)
+        mse_daug = np.mean(np.square(a_nodaug_da - a_daug_da), axis=1)
+
+        # Compute invariance score
+        mse_sum = np.repeat(np.reshape(np.sum(mse_matrix, axis=1),
+                                       (n_images, 1)), 
+                            repeats=n_daug_rep, axis=1)
+        invariance = 1 - n_images * np.divide(mse_daug, mse_sum)
+
+        print('Dimensionality activations: {}x{}x{}'.format(
+            n_images, dim_activations, n_daug_rep))
+
+        # Store HDF5 file
+        if FLAGS.output_mse_matrix_hdf5:
+            mse_matrix_ds = hdf5_layer.create_dataset(
+                    'mse_matrix', shape=mse_matrix.shape, dtype=K.floatx())
+            mse_daug_ds = hdf5_layer.create_dataset(
+                    'mse_daug', shape=mse_daug.shape, dtype=K.floatx())
+            invariance_ds = hdf5_layer.create_dataset(
+                    'invariance', shape=invariance.shape, dtype=K.floatx())
+
+            invariance = np.ravel(invariance)
+        else:
+            time_init = time()
+            invariance = np.ravel(invariance)
+            time_end = time()
+            print('Elapsed time: {}'.format(time_end - time_init))
+
+        print('Invariance score at layer', layer_name)
+        print('Min: ', np.min(invariance))
+        print('Max: ', np.max(invariance))
+        print('Mean:', np.mean(invariance))
+
+        # Update pandas data frame for plotting
+        df_end_idx = df_init_idx + n_images * n_daug_rep
+        d = pd.DataFrame({'Layer': layer_name,
+                          'sample': np.repeat(np.arange(n_images), n_daug_rep),
+                          'n_daug': np.tile(np.arange(n_daug_rep), n_images),
+                          'invariance': invariance}, 
+                          index=np.arange(df_init_idx, df_end_idx).tolist())
+        df = df.append(d)
+        df_init_idx += df_end_idx
+
+
+    pickle.dump(df, open(output_pickle, 'wb'))
+    output_hdf5.close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--data_file',
+        type=str,
+        default='/mnt/data/alex/datasets/hdf5/fmri_images.hdf5'
+                'cifar10.hdf5',
+        help='Path to the HDF5 file containing the data set.'
+    )
+    parser.add_argument(
+        '--group',
+        type=str,
+        default='fmri',
+        help='Group name in the HDF5 file indicating the train data set.'
+    )
+    parser.add_argument(
+        '--chunk_size',
+        type=int,
+        default=None,
+        help='Size of the dask array chunks'
+    )
+    parser.add_argument(
+        '--batch_size',
+        type=int,
+        default=128,
+        help='Batch size for iterating over the data set'
+    )
+    parser.add_argument(
+        '--pct',
+        type=float,
+        default=1.,
+        help='Percentage of the data set to use'
+    )
+    parser.add_argument(
+        '--shuffle',
+        action='store_true',
+        dest='shuffle',
+        help='Whether to shuffle the samples, if pct is less than 1'
+    )
+    parser.add_argument(
+        '--seed',
+        type=int,
+        dest='seed',
+        help='Random seed for the data shuffling'
+    )
+    parser.add_argument(
+        '--daug_params',
+        type=str,
+        default='nodaug.yml',
+        help='Base name of the configuration file with the data augmentation '
+             'parameters. It is expected to be located in '
+             './daug_schemes/<dataset>/'
+    )
+    parser.add_argument(
+        '--n_daug_rep',
+        type=int,
+        default=1,
+        help='The number of HDF5 files with activations from data augmentation'
+    )
+    parser.add_argument(
+        '--output_dir',
+        type=str,
+        default='-1',
+        help='Directory where to write the output files. If -1, the directory'
+             'of the model is used'
+    )
+    parser.add_argument(
+        '--output_mse_matrix_hdf5',
+        type=str,
+        default=None,
+        help='Output HDF5 file'
+    )
+    parser.add_argument(
+        '--output_pickle',
+        type=str,
+        default=None,
+        help='Output pickled file containing the invariance scores'
+    )
+    parser.add_argument(
+        '--model',
+        type=str,
+        default=None,
+        help='Model file (architecture + weights + optimizer state) to load'
+    )
+    parser.add_argument(
+        '--layer_regex',
+        type=str,
+        default='g[0-9]b[0-9]add',
+        help='Regular expression of the name of the layer at which the '
+             'activations will be computed'
+    )
+    parser.add_argument(
+        '--memory_limit',
+        type=int,
+        default=128,
+        help='Memory limit for the dask client [GB]'
+    )
+    parser.add_argument(
+        '--store_input',
+        action='store_true',
+        dest='store_input',
+        help='If True, store the input data'
+    )
+    parser.add_argument(
+        '--store_labels',
+        action='store_true',
+        dest='store_labels',
+        help='If True, store the labels and the predictions'
+    )
+
+    FLAGS, unparsed = parser.parse_known_args()
+    main()

--- a/test.py
+++ b/test.py
@@ -29,7 +29,7 @@ from surgery import ablate_activations, del_mse_nodes, del_extra_nodes
 from surgery import network2dict, restore_nodes
 
 from utils import print_flags
-from utils import pairwise_loss, invariance_loss, mean_loss
+from utils import pairwise_loss, invariance_loss, mean_loss, triplet_loss
 from utils import handle_metrics
 from utils import prepare_test_config, numpy_to_python
 from utils import print_test_results, write_test_results

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 
 import numpy as np
 import dask.array as da
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import tensorflow.compat.v1.keras.backend as K
 from tensorflow.compat.v1.keras.models import load_model
 from tensorflow.compat.v1.keras.models import Model
@@ -45,6 +45,10 @@ FLAGS = None
 
 def main(argv=None):
 
+    config = tf.ConfigProto()
+    config.gpu_options.allow_growth = True
+    K.set_session(tf.Session(config=config))
+
     K.set_floatx('float32')
 
     print_flags(FLAGS)
@@ -58,7 +62,14 @@ def main(argv=None):
     test_config = prepare_test_config(test_config, FLAGS)
 
     # Load model
-    model = load_model(os.path.join(FLAGS.model))
+    model = load_model(
+        os.path.join(FLAGS.model), 
+        custom_objects = {
+            'invariance_loss': invariance_loss,
+            'triplet_loss': triplet_loss,
+            'pairwise_loss': pairwise_loss,
+            'mean_loss': mean_loss
+            })
 
     # Open HDF5 file containing the data set and get images and labels
     hdf5_file = h5py.File(FLAGS.data_file, 'r')

--- a/test.py
+++ b/test.py
@@ -129,8 +129,12 @@ def test(images_tt, labels_tt, images_tr, labels_tr, model, test_config,
     results_dict : dict
         Dictionary containing some performance metrics
     """
-    # Ensure the model has no MSE nodes and outputs
-    model = del_mse_nodes(model)
+    # Ensure the model has no MSE nodes and outputs by building a new model
+    # with the old models weights and only the softmax output
+    softmax_layers = [layer for layer in model.layers if layer.name=='softmax']
+    assert len(softmax_layers) == 1, 'Model has multiple softmax layers'
+    softmax_layer = softmax_layers[0]
+    model = Model(model.input, softmax_layer.output)
 
     results_dict = {}
     daug_params_dicts = {}

--- a/train.py
+++ b/train.py
@@ -460,6 +460,22 @@ def _model_setup(train_config, metrics, resume_training=None):
                 'pairwise_loss': pairwise_loss,
                 'mean_loss': mean_loss
                 })
+
+        #x = model.get_layer('output_inv').output
+        #x = Dense(128, activation='relu', use_bias=True, 
+        #    kernel_initializer='he_normal', bias_initializer='zeros',
+        #    name='dense1')(x)
+        #x = BatchNormalization(name='bn_dense1')(x)
+        #x = Dense(256, activation='relu', use_bias=True, 
+        #    kernel_initializer='he_normal', bias_initializer='zeros',
+        #    name='dense2')(x)
+        #x = BatchNormalization(name='bn_dense2')(x)
+        #x = Dense(10, activation='linear', use_bias=True, 
+        #    kernel_initializer='he_normal', bias_initializer='zeros',
+        #    name='dense3')(x)
+        #x = Activation('softmax', name='softmax')(x)
+        #model = Model(model.input, x)
+
         train_config.train.initial_epoch = int(resume_training.split('_')[-1])
     else:
         model = _model_init(train_config)

--- a/train.py
+++ b/train.py
@@ -476,6 +476,14 @@ def _model_setup(train_config, metrics, resume_training=None):
         #x = Activation('softmax', name='softmax')(x)
         #model = Model(model.input, x)
 
+        ## Freeze model weights except for classification layer
+        #for layer in model.layers:
+        #    if not 'logits' in layer.name and not 'dense' in layer.name:
+        #        print(layer.name, ': frozen')
+        #        layer.trainable = False
+        #    else:
+        #        print(layer.name, ': trainable')
+
         train_config.train.initial_epoch = int(resume_training.split('_')[-1])
     else:
         model = _model_init(train_config)

--- a/train.py
+++ b/train.py
@@ -660,6 +660,15 @@ def _model_init(train_config):
                     weight_decay=train_config.network.reg.weight_decay,
                     batch_norm=train_config.network.batch_norm,
                     invariance=train_config.optimizer.invariance)
+    elif train_config.network.name == 'tripletcnn':
+        model = networks.tripletcnn(
+                    train_config.data.image_shape, 
+                    train_config.data.n_classes,
+                    dropout=train_config.network.reg.dropout,
+                    weight_decay=train_config.network.reg.weight_decay,
+                    batch_norm=train_config.network.batch_norm,
+                    use_triplet_loss=train_config.triplet_loss,
+                    use_inv_outputs=train_config.optimizer.invariance)
     else:
         raise(NotImplementedError('Network name not implemented'))
 

--- a/utils.py
+++ b/utils.py
@@ -490,6 +490,12 @@ def prepare_train_config(train_config, flags):
         train_config['network']['batch_norm'] = True
     if flags.no_batch_norm:
         train_config['network']['batch_norm'] = False
+    train_config['triplet_loss'] = flags.triplet_loss
+    if flags.svc_score_every:
+        train_config['svc_score'] = True
+        train_config['svc_score_freq'] = flags.svc_score_every
+    else:
+        train_config['svc_score'] = False
 
     # Set simulation parameters
     if flags.simulate_norep_samples:


### PR DESCRIPTION
Amongst others, this pull request adds 
- an online triplet loss incorporating class labels as well as data augmentation labels
- a new network, TripletCNN, which serves as a baseline architecture for comparing configurations of the triplet loss
- further Tensorflow 2 compatibility across a range of files
- training an SVC on the invariance layers embeddings to check classification performance